### PR TITLE
Add try/except for AttributeError

### DIFF
--- a/nautobot_plugin_chatops_panorama/utils/panorama.py
+++ b/nautobot_plugin_chatops_panorama/utils/panorama.py
@@ -212,13 +212,7 @@ def get_all_rules(device: str, pano: Panorama) -> list:
     Returns:
         list: List of rules
     """
-    try:
-        # This command sometimes throws this error:
-        #   AttributeError: 'NoneType' object has no attribute 'split'
-        # Omitting expand_vsys=False will resolve this issue
-        devices = pano.refresh_devices(expand_vsys=False, include_device_groups=False)
-    except AttributeError:
-        devices = pano.refresh_devices(include_device_groups=False)
+    devices = pano.refresh_devices(include_device_groups=False)
     device = pano.add(devices[0])
     # TODO: Future - filter by name input, the query/filter in Nautobot DB and/or Panorama
     # if not device:


### PR DESCRIPTION
Fixes an error where the refreshing of devices occasionally throws an AttributeError when `expand_vsys=False` is set.