### PR TITLE
Remove Chip from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner(s) of all files in this repository
-* @itdependsnetworks @chipn @jeffkala @matt852 @qduk @jdrew82
+* @itdependsnetworks @jeffkala @matt852 @qduk @jdrew82


### PR DESCRIPTION
Chip shouldn't be in the code owners list anymore so I've removed his username.